### PR TITLE
一部メニュー画像名の頭文字を小文字に変更

### DIFF
--- a/menu.html
+++ b/menu.html
@@ -46,7 +46,7 @@
                         </ul>
                     </div>
                     <div class="menu-photo">
-                        <img src="images/menu/Coffee.png" alt="コーヒー写真">
+                        <img src="images/menu/coffee.png" alt="コーヒー写真">
                     </div>
                 </div>
 
@@ -60,7 +60,7 @@
                         </ul>
                     </div>
                     <div class="menu-photo">
-                        <img src="images/menu/Tea.png" alt="紅茶写真">
+                        <img src="images/menu/tea.png" alt="紅茶写真">
                     </div>
                 </div>
 
@@ -74,7 +74,7 @@
                         </ul>
                     </div>
                     <div class="menu-photo">
-                        <img src="images/menu/Dessert.png" alt="デザート写真">
+                        <img src="images/menu/dessert.png" alt="デザート写真">
                     </div>
                 </div>
 


### PR DESCRIPTION
io画面では適切に画像が表示されなかったため、images/menuのファイル名と一致させた。エクスプローラーからは大文字小文字関係なく表示できた。これでioで表示できなかったらまじでわからん、ごめん。